### PR TITLE
Homebridge compatibility

### DIFF
--- a/switchbotCurtain
+++ b/switchbotCurtain
@@ -66,8 +66,12 @@ def refresh()
         
         if(null != respData.body?.slidePosition)
         {
-            sendEvent(name: "position", value: respData.body.slidePosition)
-            sendEvent(name: "level", value: respData.body.slidePosition)
+            /* homebridge compatibility
+            sendEvent(name: "position", value: 100-respData.body.slidePosition)
+            sendEvent(name: "level", value: 100-respData.body.slidePosition)
+            */
+            sendEvent(name: "position", value: 100-respData.body.slidePosition)
+            sendEvent(name: "level", value: 100-respData.body.slidePosition)
         }
         
         def windowShade = "unknown"
@@ -78,8 +82,12 @@ def refresh()
             def respData2 = getParent()?.readDeviceStatus(id)
             if(null != respData2?.body?.slidePosition && null != respData.body.slidePosition)
             {
+                /* homebridge compatibility
                 windowShade =
                     (respData2.body.slidePosition.toInteger() > respData.body.slidePosition.toInteger()) ? "closing" : "opening"
+                */
+                windowShade =
+                    (respData2.body.slidePosition.toInteger() < respData.body.slidePosition.toInteger()) ? "closing" : "opening"
                 switchState = "on"                
             }
             
@@ -90,6 +98,7 @@ def refresh()
         {
             switch(respData.body.slidePosition.toInteger())
             {
+                /* homebridge compatibility
                 case 95..100:
                     windowShade = "closed"
                     switchState = "off"
@@ -97,6 +106,15 @@ def refresh()
                 case 0..5:
                     windowShade = "open"
                     switchState = "on"
+                    break
+                */
+                case 95..100:
+                    windowShade = "open"
+                    switchState = "on"
+                    break
+                case 0..5:
+                    windowShade = "closed"
+                    switchState = "off"
                     break
                 default:
                     windowShade = "partially open"
@@ -156,7 +174,10 @@ def setPosition(position)
     def id = getParent()?.getId(device.getDeviceNetworkId())
     if(id)
     {
-        def respData = getParent()?.writeDeviceCommand(id, "setPosition", "0,ff,${position}", "command")
+        /* homebridge compatibility
+        def respData = getParent()?.writeDeviceCommand(id, "setPosition", "0,ff,${100-position}", "command")
+        */
+        def respData = getParent()?.writeDeviceCommand(id, "setPosition", "0,ff,${100-position}", "command")
         runIn(2, refresh)
     }    
 }

--- a/switchbotCurtain
+++ b/switchbotCurtain
@@ -29,7 +29,7 @@ Change history:
 
 metadata
 {
-    definition(name: "SwitchBot Curtain", namespace: "tomw", author: "tomw", importUrl: "")
+    definition(name: "SwitchBot Curtain", namespace: "tomw", author: "tomw", importUrl: "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/switchbotCurtain")
     {
         capability "Initialize"
         capability "Refresh"


### PR DESCRIPTION
Hi, I had hardtime with my integration and found out on other curtains that the way home bridge (therefore HomeKit) faces status is the "open amount" - that means 80% is 80% open not closed. I changed some of the references here (still using magic number 100, not variable) and it worked. I still didn't have time to see where it reports the status to make sure it's always correct (even during movement). Also, the open/close action is triggering some default command, which works, but sets the numbers to something different. I also saw on other drivers a property to use or not this inversion, which could be a great improvement.