### PR TITLE
Adding support for Water Leak Detector, v0.9.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubitat_switchBot
 
-This provides various driver capabilities for SwitchBot devices, including the humidity/temperature meter, bot, curtain, humidifier, strip light, color bulb (using the strip light driver), smart lock, motion sensor, contact sensor, plug mini, and hub IR functionality.  
+This provides various driver capabilities for SwitchBot devices, including the humidity/temperature meter, bot, curtain, humidifier, strip light, color bulb (using the strip light driver), smart lock, motion sensor, contact sensor, water leak detector, plug mini, and hub IR functionality.  
 
 Note that all operations have a cloud (internet) interaction.  The HTTP accesses are made according to the SwitchBotAPI reference:
 * https://github.com/OpenWonderLabs/SwitchBotAPI
@@ -15,7 +15,7 @@ Installing with Hubitat Package Manager (HPM) is recommended.
     * Your Token and Secret Key, which can be acquired as described in the SwitchBotAPI reference: https://github.com/OpenWonderLabs/SwitchBotAPI#getting-started
     * The refresh interval in seconds
         * Note that there is a documented limit of 1000 API accesses per day, and each device refresh or action is at least one access.  Set this number accordingly.
-* OPTIONAL: in the *Apps Code* section of Hubitat, add the switchbotEventsApp.  This step is necessary if you plan to use the webhook feature for real-time device status updates (currently supported for Meter, Meter Plus, Strip Light, Smart Lock, Motion Sensor, and Contact Sensor).
+* OPTIONAL: in the *Apps Code* section of Hubitat, add the switchbotEventsApp.  This step is necessary if you plan to use the webhook feature for real-time device status updates (currently supported for Meter, Meter Plus, Strip Light, Smart Lock, Motion Sensor, Contact Sensor, and Water Leak Detector).
     * In the *Apps* section of Hubitat, select *Add User App* and install the SwitchBot Events app.  Select your SwitchBot System device and click Done.
     * Note that some devices only report a subset of their attributes in real-time events.  For example, the Contact Sensor only reports open/close status and the Motion Sensor only reports active/inactive status.
 

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "hubitat_switchbot",
   "author": "tomw",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2021-01-12",
   "drivers": [
@@ -88,6 +88,13 @@
       "namespace": "tomw",
       "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/switchbotBlindTilt",
       "required": false
+    },
+    {
+      "id": "d171c8fe-3362-445c-9fd6-f461bc694e73",
+      "name": "SwitchBot Water Leak Detector",
+      "namespace": "tomw",
+      "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/switchbotWaterLeakDetector",
+      "required": false
     }
   ],
   "apps": [
@@ -100,7 +107,7 @@
     }  
   ],
   "licenseFile": "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/LICENSE",
-  "releaseNotes": "0.9.21 - tomw - Added Hub 2 and Indoor/Outdoor meter support.\n0.9.20 - tomw - Added Blind Tilt support.\n0.9.19 - tomw - improved/completed support for invertPosition.\n0.9.18 - tomw - Added Color Bulb support (in SwitchBot Strip Light driver).\n0.9.17 - tomw - Added support for remaining built-in IR commands.\n0.9.16 - tomw - add invertPosition option and simplify refresh() logic for SwitchBot Curtain driver.\n0.9.15 - tomw - Added Plug Mini support.\n0.9.14 - tomw - API v1.1 support.\n0.9.13 - tomw - Added Contact Sensor and Motion Sensor support.\n0.9.12 - tomw - Added Smart Lock and webhook events support.\n0.9.11 - tomw - Added Strip Light support.\n0.9.10 - tomw -  Added MeterPlus support.\n0.9.9 - tomw -  Add PushableButton to Bot.\n0.9.8 - tomw - Bugfix for windowShade and switch parameters.\n0.9.7 - droath - Update to report switch states on IR devices when they are operated through Hubitat.\n0.9.6 - tomw - Added Humidifier support.\n0.9.5 - tomw - Swallow unknown API replies instead of using \"unknown\".\n0.9.4 - tomw - Add SwitchLevel (dimmer) functionality for ease-of-use.  setLevel functions as an alias for setPosition.\n0.9.3 - tomw - Modified child device creation to reduce confusion around grouped Curtain devices.\n0.9.2 - tomw - More Curtain debugging.\n0.9.1 - tomw - Updated Curtain driver after debugging.  Thanks dadarkgtprince for testing and feedback.\n0.9.0 - tomw - Initial release.  HT Meter and IR functionality fully tested.  Other devices untested and released as public beta.",
+  "releaseNotes": "0.9.22 - cmartyniuk - Added Water Leak Detector.\n0.9.21 - tomw - Added Hub 2 and Indoor/Outdoor meter support.\n0.9.20 - tomw - Added Blind Tilt support.\n0.9.19 - tomw - improved/completed support for invertPosition.\n0.9.18 - tomw - Added Color Bulb support (in SwitchBot Strip Light driver).\n0.9.17 - tomw - Added support for remaining built-in IR commands.\n0.9.16 - tomw - add invertPosition option and simplify refresh() logic for SwitchBot Curtain driver.\n0.9.15 - tomw - Added Plug Mini support.\n0.9.14 - tomw - API v1.1 support.\n0.9.13 - tomw - Added Contact Sensor and Motion Sensor support.\n0.9.12 - tomw - Added Smart Lock and webhook events support.\n0.9.11 - tomw - Added Strip Light support.\n0.9.10 - tomw -  Added MeterPlus support.\n0.9.9 - tomw -  Add PushableButton to Bot.\n0.9.8 - tomw - Bugfix for windowShade and switch parameters.\n0.9.7 - droath - Update to report switch states on IR devices when they are operated through Hubitat.\n0.9.6 - tomw - Added Humidifier support.\n0.9.5 - tomw - Swallow unknown API replies instead of using \"unknown\".\n0.9.4 - tomw - Add SwitchLevel (dimmer) functionality for ease-of-use.  setLevel functions as an alias for setPosition.\n0.9.3 - tomw - Modified child device creation to reduce confusion around grouped Curtain devices.\n0.9.2 - tomw - More Curtain debugging.\n0.9.1 - tomw - Updated Curtain driver after debugging.  Thanks dadarkgtprince for testing and feedback.\n0.9.0 - tomw - Initial release.  HT Meter and IR functionality fully tested.  Other devices untested and released as public beta.",
   "documentationLink": "https://github.com/tomwpublic/hubitat_switchbot/blob/main/README.md",
   "communityLink": "https://community.hubitat.com/t/switchbot-gets-an-open-api/61217/17"
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -93,7 +93,7 @@
       "id": "d171c8fe-3362-445c-9fd6-f461bc694e73",
       "name": "SwitchBot Water Leak Detector",
       "namespace": "tomw",
-      "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/switchbotWaterLeakDetector",
+      "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_switchbot/main/switchbotWaterDetector",
       "required": false
     }
   ],

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "hubitat_switchbot",
   "author": "tomw",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2021-01-12",
   "drivers": [

--- a/switchbotEventsApp
+++ b/switchbotEventsApp
@@ -18,6 +18,7 @@ limitations under the License.
 
 Change history:
 
+0.9.23 - cmartyniuk - added water leak detector 
 0.9.21 - tomw -
     Added temperature and humidity support for Hub 2 (as SwitchBot Meter child).
     Added Indoor/Outdoor Thermo-Hygrometer (in SwitchBot Meter driver).
@@ -162,11 +163,11 @@ def processEvent(eventMap)
     logDebug("incoming event: ${eventMap}")
     
     if("changeReport" != eventMap?.eventType) { return }
-    
+
     // check whether we know about this type of device
-    def devTypeInfo = deviceTypesMap.getAt(eventMap.context.deviceType)    
+    def devTypeInfo = deviceTypesMap.getAt(eventMap.context.deviceType)        
     if(!devTypeInfo) { return }
-    
+
     // build the event that we'll pass to the driver
     def newEvent = [:]
     
@@ -194,6 +195,7 @@ import groovy.transform.Field
 
 @Field deviceTypesMap =
     [
+        "Water Detector": [name: "Water Detector", attrs: waterDetectorAttrsMap],
         WoContact: [name: "Contact Sensor", attrs: contactSensorAttrsMap],
         WoLock: [name: "Smart Lock"],
         WoMeter: [name: "Meter"],
@@ -224,6 +226,11 @@ static @Field contactSensorAttrsMap =
 static @Field motionSensorAttrsMap =
     [
         detectionState: "moveDetected"
+    ]
+
+static @Field waterDetectorAttrsMap =
+    [
+        detectionState: "status"
     ]
 
 

--- a/switchbotSystem
+++ b/switchbotSystem
@@ -18,6 +18,7 @@ limitations under the License.
 
 Change history:
 
+0.9.23 - cmartyniuk - added water leak detector 
 0.9.21 - tomw -
     Added temperature, humidity, and lightLevel support for Hub 2 (in SwitchBot Meter driver).
     Added Indoor/Outdoor Thermo-Hygrometer (in SwitchBot Meter driver).
@@ -294,7 +295,7 @@ def createChildDevice(name, id, deviceType)
 {
     try
     {
-        def customDevTypes = ["Bot", "Curtain", "Meter", "IR Device", "Humidifier", "Strip Light", "Smart Lock", "Motion Sensor", "Contact Sensor", "Plug Mini", "Blind Tilt"]
+        def customDevTypes = ["Bot", "Curtain", "Meter", "IR Device", "Humidifier", "Strip Light", "Smart Lock", "Motion Sensor", "Contact Sensor", "Water Detector", "Plug Mini", "Blind Tilt"]
         def genericDevTypes = []
         
         deviceType = deviceType.toString()

--- a/switchbotWaterDetector
+++ b/switchbotWaterDetector
@@ -1,0 +1,65 @@
+/*
+
+Copyright 2024 - chrism based on tomw
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------
+
+Change history:
+
+0.9.23 - cmartyniuk - added water leak detector 
+
+*/
+
+metadata
+{
+    definition(name: "SwitchBot Water Detector", namespace: "tomw", author: "tomw", importUrl: "")
+    {
+        capability "Water Sensor"
+        capability "Initialize"
+        capability "Refresh"
+
+        attribute "battery", "string"        
+    }
+}
+
+def initialize()
+{
+    sendEvent(name: "water", value: "unknown") 
+    sendEvent(name: "battery", value: "unknown") 
+    
+    refresh()
+}
+
+def refresh()
+{
+    parent.refreshFromParent(device)
+}
+
+def parse(body)
+{
+    if(!body) { return }
+    
+    log.debug body
+
+    if(null != body.battery)
+    {
+        sendEvent(name: "battery", value: body.battery)
+    }
+
+    if(null != body.status)
+    {
+        sendEvent(name: "water", value: body.status ? "wet" : "dry")
+    }
+}


### PR DESCRIPTION
- Added and tested support for the water leak detector, which reports a 'water' state as "wet" or "dry" and also reports the device battery level
- Updated the readme and the package manifest for the hubitat package manager
- Bumped the version to v0.9.23